### PR TITLE
fixed tab order in .p8 output file

### DIFF
--- a/src/build.mjs
+++ b/src/build.mjs
@@ -21,7 +21,9 @@ export default function build(config) {
 
   let luaFilePaths = fs
     .readdirSync(config.sourceDir)
-    .filter(file => file.endsWith('.lua'));
+    .filter(file => file.endsWith('.lua'))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }));
+
 
   stats.numLuaFiles = luaFilePaths.length;
   stats.luaFiles = [];


### PR DESCRIPTION
There is a problem in build command. Tabs order is wrong, it's the natural order of the file system, on my mac, it was 1,10,11,...,2,3,... I've fixed it.